### PR TITLE
feat: proposal to add callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,17 +106,23 @@ server.get("/health-check/readiness", async (_, res) => {
           type: HealthTypes.Redis,
           name: "redis integration",
           host: "redis",
+          onSuccess: () => console.log('success') // you can call your log here
+          onFail: () => console.error('error') // you can call your log here
         },
         {
           type: HealthTypes.Memcached,
           name: "My memcache integration",
           host: "memcache:11211",
+          onSuccess: () => console.log('success') // you can call your log here
+          onFail: () => console.error('error') // you can call your log here
         },
         {
           type: HealthTypes.Web,
           name: "my web api integration",
           host: "https://github.com/status",
           headers: [{ key: "Accept", value: "application/json" }],
+          onSuccess: () => console.log('success') // you can call your log here
+          onFail: () => console.error('error') // you can call your log here
         },
       ],
     })

--- a/src/healthchecker/healthchecker.ts
+++ b/src/healthchecker/healthchecker.ts
@@ -60,9 +60,15 @@ export async function HealthcheckerDetailedCheck(config: ApplicationConfig): Pro
  */
 async function redisCheck(config: IntegrationConfig): Promise<Integration> {
   const start = new Date().getTime();
+
   const result = await checkRedisClient(config);
+
+  if (result.status && config.onSuccess) config.onSuccess()
+  if (!result.status && config.onFail) config.onFail()
+
   config.port = config.port || Defaults.RedisPort;
   config.db = config.db || Defaults.RedisDB;
+
   return {
     name: config.name || "",
     kind: HealthIntegration.RedisIntegration,
@@ -79,8 +85,13 @@ async function redisCheck(config: IntegrationConfig): Promise<Integration> {
 async function memcacheCheck(config: IntegrationConfig): Promise<Integration> {
   return new Promise((resolve, _) => {
     const start = new Date().getTime();
+
     config.timeout = config.timeout || Defaults.MemcachedTimeout;
+
     checkMemcachedClient(config).then((check) => {
+      if (check.status && config.onSuccess) config.onSuccess()
+      if (!check.status && config.onFail) config.onFail()
+
       resolve({
         name: config.name || "",
         kind: HealthIntegration.MemcachedIntegration,
@@ -98,8 +109,14 @@ async function memcacheCheck(config: IntegrationConfig): Promise<Integration> {
  */
 async function webCheck(config: IntegrationConfig): Promise<Integration> {
   const start = new Date().getTime();
+
   config.timeout = config.timeout || Defaults.WebTimeout;
+
   const result = await checkWebIntegration(config);
+
+  if (result.status && config.onSuccess) config.onSuccess()
+  if (!result.status && config.onFail) config.onFail()
+
   return {
     name: config.name || "",
     kind: HealthIntegration.WebServiceIntegration,

--- a/src/interfaces/types.ts
+++ b/src/interfaces/types.ts
@@ -34,6 +34,9 @@ export interface ApplicationConfig {
   version?: string;
   integrations: IntegrationConfig[];
 }
+
+export type genericCallbackFunction = () => void;
+
 // IntegrationConfig used to inform each integration config
 export interface IntegrationConfig {
   type: HealthTypes;
@@ -44,6 +47,8 @@ export interface IntegrationConfig {
   db?: number;
   timeout?: number;
   auth?: Auth;
+  onFail?: genericCallbackFunction;
+  onSuccess?: genericCallbackFunction;
 }
 // HTTPHeader used to setup webservices integrations
 export interface HTTPHeader {


### PR DESCRIPTION
## Proposal

When a health-check fails or succeeded, we can attach a callback function(optional) to execute after this implementation.

Example:

```js
        {
          type: HealthTypes.Redis,
          name: "redis integration",
          host: "redis",
          onSuccess: () => console.log('success') // you can call your log here
          onFail: () => console.error('error') // you can call your log here
        },
```

On the `onSucess`or `onFail`, it will send a console.log. It could be anything, like a new relic call or something like that

### Important

This is a proposal, if you all agree, I'll do the tests.