### PR TITLE
Turn off logging for sequelize DB check

### DIFF
--- a/src/services/database-service.ts
+++ b/src/services/database-service.ts
@@ -10,6 +10,7 @@ export async function checkDatabaseClient(config: IntegrationConfig): Promise<HT
       dialect: dbDialect || "mysql",
       port: dbPort,
       host,
+      logging: false,
     });
     // check authenticate to database
     try {


### PR DESCRIPTION
This PR disables logging for sequelize. Eliminating `Executing (default): SELECT 1+1 AS result` from the logs